### PR TITLE
Update SpringResourceLoader.java

### DIFF
--- a/spring-context-velocity/src/main/java/org/springframework/ui/velocity/SpringResourceLoader.java
+++ b/spring-context-velocity/src/main/java/org/springframework/ui/velocity/SpringResourceLoader.java
@@ -100,8 +100,14 @@ public class SpringResourceLoader extends ResourceLoader {
 			logger.debug("Looking for Velocity resource with name [" + source + "]");
 		}
 		for (String resourceLoaderPath : this.resourceLoaderPaths) {
+			String location;
+			if (source.startsWith("/")) {
+				location = resourceLoaderPath + source.replaceFirst("/", "");
+			}else{
+				location = resourceLoaderPath + source;
+			}
 			org.springframework.core.io.Resource resource =
-					this.resourceLoader.getResource(resourceLoaderPath + source);
+					this.resourceLoader.getResource(location);
 			try {
 				return resource.getInputStream();
 			}


### PR DESCRIPTION
因为resourceLoaderPath肯定是以斜杠结尾的， 当模板里遇到比如#parse("/head.vm")这种写法时，最终的location会变成//head.vm，有两个斜杠，此时resourceLoader就找不到资源了。